### PR TITLE
feat: store crawler output as PecVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ export DATABASE_URL="sqlite+aiosqlite:///./pec.sqlite3"
 
 uvicorn main:app --host 0.0.0.0 --port 8000
 
+# testar com curl
+
+curl -X POST http://localhost:8000/run
+curl http://localhost:8000/last
+
 # Banco de dados inicial
 
 ```sql
@@ -28,7 +33,7 @@ CREATE TABLE pec_versions (
 
 # Reference (endpoints)
 
-- POST /run — executa agora e persiste.
-- GET /last — último resultado (do DB).
-- GET /runs?limit=20 — histórico recente.
+- POST /run — executa agora e persiste nova versão.
+- GET /last — última versão persistida.
+- GET /runs?limit=20 — histórico recente de versões.
 - GET /healthz — health check.

--- a/crud.py
+++ b/crud.py
@@ -1,28 +1,32 @@
 from typing import Dict, Any, Optional
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from models import CrawlerRun
 
-async def save_run(session: AsyncSession, status: str, data: Dict[str, Any]) -> CrawlerRun:
-    row = CrawlerRun(
-        status=status,
-        versao_label=data.get("versao_label"),
-        url_release_page=data.get("url_release_page"),
-        link_linux=data.get("link_linux"),
-        source=data.get("source"),
-        payload=data,
+from models import PecVersion
+
+
+async def save_version(session: AsyncSession, data: Dict[str, Any]) -> PecVersion:
+    row = PecVersion(
+        version=data["versao_label"],
+        download_link=data["link_linux"],
+        release_notes_page=data.get("url_release_page"),
+        release_notes_summary=data.get("release_notes_summary"),
     )
     session.add(row)
     await session.commit()
     await session.refresh(row)
     return row
 
-async def get_last_run(session: AsyncSession) -> Optional[CrawlerRun]:
-    stmt = select(CrawlerRun).order_by(CrawlerRun.id.desc()).limit(1)
+
+async def get_last_version(session: AsyncSession) -> Optional[PecVersion]:
+    stmt = select(PecVersion).order_by(PecVersion.id.desc()).limit(1)
     res = await session.execute(stmt)
     return res.scalar_one_or_none()
 
-async def list_runs(session: AsyncSession, limit: int = 20):
-    stmt = select(CrawlerRun).order_by(CrawlerRun.id.desc()).limit(limit)
+
+async def list_versions(session: AsyncSession, limit: int = 20):
+    stmt = select(PecVersion).order_by(PecVersion.id.desc()).limit(limit)
     res = await session.execute(stmt)
     return list(res.scalars().all())
+

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from env import settings
 from helpers import run_pec_crawler, now_iso, parse_time_hhmm
 from database import init_db, get_session
 from sqlalchemy.ext.asyncio import AsyncSession
-from crud import save_run, get_last_run, list_runs
+from crud import save_version, get_last_version, list_versions
 
 app = FastAPI(title=settings.APP_NAME, version="1.0.0")
 scheduler = AsyncIOScheduler()
@@ -20,44 +20,50 @@ async def daily_job():
     LAST_RESULT = payload
     # Persistir
     async for session in get_session():
-        await save_run(session, status, data)
+        if status == "success":
+            await save_version(session, data)
 
 @app.get("/healthz")
 async def healthz():
+    """Verifica se a API está ativa."""
     return {"ok": True, "ts": now_iso()}
 
 @app.post("/run")
 async def run_now(session: AsyncSession = Depends(get_session)):
+    """Executa o crawler imediatamente."""
     status, data = await run_pec_crawler()
-    row = await save_run(session, status, data)
-    return {"status": status, "data": data, "id": row.id, "execution_time": now_iso()}
+    row_id = None
+    if status == "success":
+        row = await save_version(session, data)
+        row_id = row.id
+    return {"status": status, "data": data, "id": row_id, "execution_time": now_iso()}
 
 @app.get("/last")
 async def last(session: AsyncSession = Depends(get_session)):
-    row = await get_last_run(session)
+    """Última versão persistida."""
+    row = await get_last_version(session)
     if not row:
         return LAST_RESULT
     return {
         "id": row.id,
-        "status": row.status,
-        "versao_label": row.versao_label,
-        "url_release_page": row.url_release_page,
-        "link_linux": row.link_linux,
-        "source": row.source,
+        "version": row.version,
+        "download_link": row.download_link,
+        "release_notes_page": row.release_notes_page,
+        "release_notes_summary": row.release_notes_summary,
         "created_at": row.created_at,
-        "payload": row.payload,
     }
 
 @app.get("/runs")
 async def runs(limit: int = Query(20, ge=1, le=200), session: AsyncSession = Depends(get_session)):
-    rows = await list_runs(session, limit=limit)
+    """Lista versões recentes."""
+    rows = await list_versions(session, limit=limit)
     return [
         {
             "id": r.id,
-            "status": r.status,
-            "versao_label": r.versao_label,
+            "version": r.version,
             "created_at": r.created_at,
-        } for r in rows
+        }
+        for r in rows
     ]
 
 @app.on_event("startup")

--- a/models.py
+++ b/models.py
@@ -1,21 +1,9 @@
-from typing import Optional, Any, Dict
+from typing import Optional, Any
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy import String, Text, DateTime, JSON, func, Integer
+from sqlalchemy import String, Text, DateTime, func, Integer
 
 class Base(DeclarativeBase):
     pass
-
-class CrawlerRun(Base):
-    __tablename__ = "crawler_runs"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    status: Mapped[str] = mapped_column(String(16), nullable=False)
-    versao_label: Mapped[Optional[str]] = mapped_column(String(32))
-    url_release_page: Mapped[Optional[str]] = mapped_column(Text)
-    link_linux: Mapped[Optional[str]] = mapped_column(Text)
-    source: Mapped[Optional[str]] = mapped_column(String(64))
-    payload: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON)  # dados completos da extração
-    created_at: Mapped[Any] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 class PecVersion(Base):
     __tablename__ = "pec_versions"


### PR DESCRIPTION
## Summary
- persist crawler results directly in `PecVersion`
- document curl examples and endpoints
- add descriptions to FastAPI routes

## Testing
- `python -m py_compile models.py crud.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c13db5c832193c02e0287bc94a8